### PR TITLE
Support Non-NIO Scenarios

### DIFF
--- a/selector/src/binks/java/net/neoforged/jarjar/selector/JarSelectorTest.java
+++ b/selector/src/binks/java/net/neoforged/jarjar/selector/JarSelectorTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -166,16 +165,16 @@ public class JarSelectorTest {
             this.name = name;
         }
 
-        public Optional<InputStream> getResource(final Path path) {
-            if (path.toString().contains("metadata") && metadata != null) {
+        public Optional<InputStream> getResource(final String path) {
+            if (path.contains("metadata") && metadata != null) {
                 return Optional.of(MetadataIOHandler.toInputStream(metadata));
             }
 
             return Optional.empty();
         }
 
-        public Optional<SelectionSource> getInternal(final Path path) {
-            if (internalSource != null && path.toString().contains(internalSource.getName())) {
+        public Optional<SelectionSource> getInternal(final String path) {
+            if (internalSource != null && path.contains(internalSource.getName())) {
                 return Optional.of(internalSource);
             }
 

--- a/selector/src/main/java/net/neoforged/jarjar/selection/JarSelector.java
+++ b/selector/src/main/java/net/neoforged/jarjar/selection/JarSelector.java
@@ -9,8 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -18,15 +16,16 @@ import java.util.stream.Collectors;
 
 public final class JarSelector {
     private static final Logger LOGGER = LoggerFactory.getLogger(JarSelector.class);
+    public static final String CONTAINED_JARS_METADATA_PATH = "META-INF/jarjar/metadata.json";
 
     private JarSelector() {
         throw new IllegalStateException("Can not instantiate an instance of: JarSelector. This is a utility class");
     }
 
-    public static <T, E extends Throwable> List<T> detectAndSelect(
+    public static <T, E extends Throwable, R> List<T> detectAndSelect(
             final List<T> source,
-            final BiFunction<T, Path, Optional<InputStream>> resourceReader,
-            final BiFunction<T, Path, Optional<T>> sourceProducer,
+            final BiFunction<T, String, Optional<InputStream>> resourceReader,
+            final BiFunction<T, String, Optional<T>> sourceProducer,
             final Function<T, String> identificationProducer,
             final Function<Collection<ResolutionFailureInformation<T>>, E> failureExceptionProducer
     ) throws E {
@@ -68,7 +67,7 @@ public final class JarSelector {
                 .filter(detectedJarsBySource::containsKey)
                 .map(selectedJarMetadata -> {
                     final Collection<T> sourceOfJar = detectedJarsBySource.get(selectedJarMetadata);
-                    return sourceProducer.apply(sourceOfJar.iterator().next(), Paths.get(selectedJarMetadata.path()));
+                    return sourceProducer.apply(sourceOfJar.iterator().next(), selectedJarMetadata.path());
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -96,14 +95,13 @@ public final class JarSelector {
 
     private static <T> Set<DetectionResult<T>> detect(
             final List<T> source,
-            final BiFunction<T, Path, Optional<InputStream>> resourceReader,
-            final BiFunction<T, Path, Optional<T>> sourceProducer,
+            final BiFunction<T, String, Optional<InputStream>> resourceReader,
+            final BiFunction<T, String, Optional<T>> sourceProducer,
             final Function<T, String> identificationProducer) {
-        final Path metadataPath = Paths.get(Constants.CONTAINED_JARS_METADATA_PATH);
         final Map<T, Optional<InputStream>> metadataInputStreamsBySource = source.stream().collect(
                 Collectors.toMap(
                         Function.identity(),
-                        t -> resourceReader.apply(t, metadataPath)
+                        t -> resourceReader.apply(t, CONTAINED_JARS_METADATA_PATH)
                 )
         );
 
@@ -129,8 +127,8 @@ public final class JarSelector {
 
     private static <T> Set<DetectionResult<T>> recursivelyDetectContainedJars(
             final Map<T, Metadata> rootMetadataBySource,
-            final BiFunction<T, Path, Optional<InputStream>> resourceReader,
-            final BiFunction<T, Path, Optional<T>> sourceProducer,
+            final BiFunction<T, String, Optional<InputStream>> resourceReader,
+            final BiFunction<T, String, Optional<T>> sourceProducer,
             final Function<T, String> identificationProducer) {
         final Set<DetectionResult<T>> results = Sets.newHashSet();
         final Map<T, T> rootSourcesBySource = Maps.newHashMap();
@@ -141,7 +139,7 @@ public final class JarSelector {
                     .forEach(results::add);
 
             for (final ContainedJarMetadata jar : entry.getValue().jars()) {
-                final Optional<T> source = sourceProducer.apply(entry.getKey(), Paths.get(jar.path()));
+                final Optional<T> source = sourceProducer.apply(entry.getKey(), jar.path());
                 if (source.isPresent()) {
                     sourcesToProcess.add(source.get());
                     rootSourcesBySource.put(source.get(), entry.getKey());
@@ -154,7 +152,7 @@ public final class JarSelector {
         while (!sourcesToProcess.isEmpty()) {
             final T source = sourcesToProcess.remove();
             final T rootSource = rootSourcesBySource.get(source);
-            final Optional<InputStream> metadataInputStream = resourceReader.apply(source, Paths.get(Constants.CONTAINED_JARS_METADATA_PATH));
+            final Optional<InputStream> metadataInputStream = resourceReader.apply(source, CONTAINED_JARS_METADATA_PATH);
             if (metadataInputStream.isPresent()) {
                 final Optional<Metadata> metadata = MetadataIOHandler.fromStream(metadataInputStream.get());
                 if (metadata.isPresent()) {
@@ -162,7 +160,7 @@ public final class JarSelector {
                             .forEach(results::add);
 
                     for (final ContainedJarMetadata jar : metadata.get().jars()) {
-                        final Optional<T> sourceJar = sourceProducer.apply(source, Paths.get(jar.path()));
+                        final Optional<T> sourceJar = sourceProducer.apply(source, jar.path());
                         if (sourceJar.isPresent()) {
                             sourcesToProcess.add(sourceJar.get());
                             rootSourcesBySource.put(sourceJar.get(), rootSource);

--- a/selector/src/main/java/net/neoforged/jarjar/selection/JarSelector.java
+++ b/selector/src/main/java/net/neoforged/jarjar/selection/JarSelector.java
@@ -16,13 +16,12 @@ import java.util.stream.Collectors;
 
 public final class JarSelector {
     private static final Logger LOGGER = LoggerFactory.getLogger(JarSelector.class);
-    public static final String CONTAINED_JARS_METADATA_PATH = "META-INF/jarjar/metadata.json";
 
     private JarSelector() {
         throw new IllegalStateException("Can not instantiate an instance of: JarSelector. This is a utility class");
     }
 
-    public static <T, E extends Throwable, R> List<T> detectAndSelect(
+    public static <T, E extends Throwable> List<T> detectAndSelect(
             final List<T> source,
             final BiFunction<T, String, Optional<InputStream>> resourceReader,
             final BiFunction<T, String, Optional<T>> sourceProducer,
@@ -101,7 +100,7 @@ public final class JarSelector {
         final Map<T, Optional<InputStream>> metadataInputStreamsBySource = source.stream().collect(
                 Collectors.toMap(
                         Function.identity(),
-                        t -> resourceReader.apply(t, CONTAINED_JARS_METADATA_PATH)
+                        t -> resourceReader.apply(t, Constants.CONTAINED_JARS_METADATA_PATH)
                 )
         );
 
@@ -152,7 +151,7 @@ public final class JarSelector {
         while (!sourcesToProcess.isEmpty()) {
             final T source = sourcesToProcess.remove();
             final T rootSource = rootSourcesBySource.get(source);
-            final Optional<InputStream> metadataInputStream = resourceReader.apply(source, CONTAINED_JARS_METADATA_PATH);
+            final Optional<InputStream> metadataInputStream = resourceReader.apply(source, Constants.CONTAINED_JARS_METADATA_PATH);
             if (metadataInputStream.isPresent()) {
                 final Optional<Metadata> metadata = MetadataIOHandler.fromStream(metadataInputStream.get());
                 if (metadata.isPresent()) {


### PR DESCRIPTION
Calling `Paths.get` on the relative paths to resource within the container can be left up to the caller, since it is trivial to adapt any current call-site to that style. It also enables users who just have `JarFile` to still make use of JarJar as-is.